### PR TITLE
input: changes no longer reset policy changes

### DIFF
--- a/src/components/RegoEditor.js
+++ b/src/components/RegoEditor.js
@@ -9,11 +9,57 @@ export function RegoEditor({
   style = "font-size: 14px;",
   opa = "http://127.0.0.1:8181/",
   id = "",
-  evalInput = {},
+  evalInput = {}, // initial input, updates are set by `<instance>.input = ...`
 } = {}) {
   const parent = document.createElement("div");
   parent.style = style;
   parent.value = value;
+
+  let input = evalInput;
+
+  const peLinter = linter(async view => {
+    const doc = view.state.doc;
+    const resp = await putPolicy(opa, id, String(editor.state.doc), false)
+    const payload = await resp.json();
+    if (payload.code) { // bad rego
+      parent.value = String(""); // this means "no query produced"
+      parent.dispatchEvent(new InputEvent("input", {bubbles: true}));
+
+      return payload.errors.map(({code, message, location: {row, col}}) => ({
+        from: doc.line(row).from + col - 1,
+        to: doc.line(row+1).from, // next line, i.e., end of line used in "from"
+        severity: "error",
+        message: `${code}: ${message}`,
+      }));
+    }
+    // If we make it this far, the policy is on the server, so let's eval it:
+    const result = (await (await evalPolicy(opa, input)).json()).result;
+    const query = result.query;
+    const errors = result.conditions?.errors;
+    if (errors) {
+      parent.value = String(""); // this means "no query produced"
+      parent.dispatchEvent(new InputEvent("input", {bubbles: true}));
+
+      return errors.map(({location: {row, col}, message, details}) => {
+        const dets = details?.details; // TODO(sr): API response shouldn't nest this like that
+        const msg = dets ? `${message} (${dets})` : message;
+        return {
+          from: doc.line(row).from + col - 1,
+          to: doc.line(row+1).from, // next line, i.e., end of line used in "from"
+          severity: "warning",
+          message: msg,
+        };
+      });
+    }
+
+    parent.value = String(result.query);
+    parent.dispatchEvent(new InputEvent("input", {bubbles: true}));
+    return [];
+  }, {
+    delay: 200,
+  });
+
+  const [_config, lintPlugin, _exts] = peLinter;
 
   const editor = new EditorView({
     parent,
@@ -21,50 +67,26 @@ export function RegoEditor({
     extensions: [
       basicSetup,
       lintGutter(),
-      linter(async view => {
-        const doc = view.state.doc;
-        const resp = await putPolicy(opa, id, String(editor.state.doc), false)
-        const payload = await resp.json();
-        if (payload.code) { // bad rego
-          parent.value = String(""); // this means "no query produced"
-          parent.dispatchEvent(new InputEvent("input", {bubbles: true}));
-
-          return payload.errors.map(({code, message, location: {row, col}}) => ({
-            from: doc.line(row).from + col - 1,
-            to: doc.line(row+1).from, // next line, i.e., end of line used in "from"
-            severity: "error",
-            message: `${code}: ${message}`,
-          }));
-        }
-        // If we make it this far, the policy is on the server, so let's eval it:
-        const result = (await (await evalPolicy(opa, evalInput)).json()).result;
-        const query = result.query;
-        const errors = result.conditions?.errors;
-        if (errors) {
-          parent.value = String(""); // this means "no query produced"
-          parent.dispatchEvent(new InputEvent("input", {bubbles: true}));
-
-          return errors.map(({location: {row, col}, message, details}) => {
-            const dets = details?.details; // TODO(sr): API response shouldn't nest this like that
-            const msg = dets ? `${message} (${dets})` : message;
-            return {
-              from: doc.line(row).from + col - 1,
-              to: doc.line(row+1).from, // next line, i.e., end of line used in "from"
-              severity: "warning",
-              message: msg,
-            };
-          });
-        }
-
-        parent.value = String(result.query);
-        parent.dispatchEvent(new InputEvent("input", {bubbles: true}));
-        return [];
-      }, {
-        delay: 200,
-      }),
+      peLinter,
     ]
   });
 
   parent.addEventListener("input", (event) => event.isTrusted && event.stopImmediatePropagation());
-  return parent;
+  return  {
+    view: parent,
+    set input(i) {
+      input = i;
+      forceLinting(editor, lintPlugin);
+    },
+  };
+}
+
+// based on discussion here:
+// https://discuss.codemirror.net/t/can-we-manually-force-linting-even-if-the-document-hasnt-changed/3570
+function forceLinting(view, lintPlugin) {
+  const plugin = view.plugin(lintPlugin);
+  if (plugin) {
+    plugin.set = true;
+    plugin.force();
+  }
 }

--- a/src/components/SQLEditor.js
+++ b/src/components/SQLEditor.js
@@ -20,6 +20,7 @@ export function SQLEditor({
       linter(async view => {
         parent.value = String(editor.state.doc);
         parent.dispatchEvent(new InputEvent("input", {bubbles: true}));
+        return [];
       }),
     ]
   });

--- a/src/index.md
+++ b/src/index.md
@@ -25,7 +25,8 @@ await putPolicy(opa, "filters.rego", filtersRego);
 <h2>Data Policy</h2>
 
 ```js
-const regoInput = view(RegoEditor({id: "filters.rego", opa, evalInput, rego: filtersRego}));
+const re = RegoEditor({id: "filters.rego", opa, input, rego: filtersRego});
+const regoInput = view(re.view);
 ```
 </div>
 <div class="card">
@@ -37,6 +38,7 @@ const evalInput0 = view(JSONEditor({value: JSON.stringify(input, null, 2)}));
 
 ```js
 const evalInput = JSON.parse(evalInput0);
+re.input = evalInput
 ```
 </div>
 </div>


### PR DESCRIPTION
The output of the Input Editor no longer is an input of RegoEditor.
This has the effect that changing the input no longer re-creates the
RegoEditor, which would have reset its contents to the defaults.

Instead, we now have a setter on RegoEditor's return object to control
its input. Furthermore, that setter forces a lint run, which uses that
input.

While doing this, also getting rid of a failed promise in the SQLEditor.
There, we're using a dummy lint run to trigger an update to its outputs
without requring a button of some sort, with the default wait behaviour:
If nothing changes for 3/4 of a second, the output is produced.